### PR TITLE
linux: Add kernel modules to image.

### DIFF
--- a/recipes-kernel/linux/linux-sparrow_mm-mr1.bb
+++ b/recipes-kernel/linux/linux-sparrow_mm-mr1.bb
@@ -33,6 +33,8 @@ do_install_append() {
     rm -rf ${D}/usr/src/usr/
 }
 
+IMAGE_INSTALL += " kernel-modules"
+
 BOOT_PARTITION = "/dev/mmcblk0p11"
 
 inherit mkboot old-kernel-gcc-hdrs


### PR DESCRIPTION
Turns out that this port doesn't package the kernel modules.
This patch fixes sensors not working.
Big thanks to @hummlbach for providing help in fixing this issue!